### PR TITLE
Fix PyInstaller packaging of spellchecker module

### DIFF
--- a/Editorial-test.spec
+++ b/Editorial-test.spec
@@ -6,6 +6,8 @@ binaries = []
 hiddenimports = []
 tmp_ret = collect_all('en_core_web_sm')
 datas += tmp_ret[0]; binaries += tmp_ret[1]; hiddenimports += tmp_ret[2]
+tmp_ret = collect_all('pyspellchecker')
+datas += tmp_ret[0]; binaries += tmp_ret[1]; hiddenimports += tmp_ret[2]
 hiddenimports += ['editorial_modes', 'editorial_indicators', 'filter_analyzer']
 
 

--- a/Editorial.spec
+++ b/Editorial.spec
@@ -6,6 +6,8 @@ binaries = []
 hiddenimports = []
 tmp_ret = collect_all('en_core_web_sm')
 datas += tmp_ret[0]; binaries += tmp_ret[1]; hiddenimports += tmp_ret[2]
+tmp_ret = collect_all('pyspellchecker')
+datas += tmp_ret[0]; binaries += tmp_ret[1]; hiddenimports += tmp_ret[2]
 hiddenimports += ['editorial_modes', 'editorial_indicators', 'filter_analyzer']
 
 

--- a/PACKAGING.md
+++ b/PACKAGING.md
@@ -29,7 +29,10 @@ Build EXE only:
 
 powershell
 & .\.venv\Scripts\Activate.ps1
-pyinstaller --noconfirm --clean --onefile --windowed --name Editorial --collect-all en_core_web_sm --collect-all spellchecker editorial.py
+pyinstaller --noconfirm --clean --onefile --windowed --name Editorial --collect-all en_core_web_sm --collect-all pyspellchecker editorial.py
+
+# Extract and decompress dictionary (for portable package and installer)
+python -c "import gzip, json, pkgutil; open('dist/dictionary.json', 'w', encoding='utf-8').write(json.dumps(json.loads(gzip.decompress(pkgutil.get_data('spellchecker', 'resources/en.json.gz')).decode('utf-8')), indent=2))"
 
 Build installer manually:
 

--- a/editorial.py
+++ b/editorial.py
@@ -459,7 +459,27 @@ class EditorialApp:
 
         self.root.config(menu=bar)
 
-        self._spellchecker = SpellChecker()
+        # Attempt to load external dictionary first
+        local_dict_path = "dictionary.json"
+
+        # Check standard locations (next to exe, or cwd)
+        if hasattr(sys, '_MEIPASS'):
+            # PyInstaller temp dir is sys._MEIPASS, but we want the directory of the executable
+            exe_dir = os.path.dirname(sys.executable)
+            possible_path = os.path.join(exe_dir, local_dict_path)
+            if os.path.exists(possible_path):
+                local_dict_path = possible_path
+
+        if os.path.exists(local_dict_path):
+            try:
+                self._spellchecker = SpellChecker(language=None, local_dictionary=local_dict_path)
+            except Exception:
+                # Fallback
+                self._spellchecker = SpellChecker()
+        else:
+            # Fallback to internal language=en
+            self._spellchecker = SpellChecker()
+
         self._ignored_words: set[str] = set()
         self._custom_dict_path = os.path.join(os.path.dirname(self._settings_path), "custom_dictionary.json")
         self._custom_dict_words: set[str] = set()

--- a/installer/Editorial.iss
+++ b/installer/Editorial.iss
@@ -42,6 +42,7 @@ Name: "desktopicon"; Description: "Create a desktop shortcut"; GroupDescription:
 
 [Files]
 Source: "..\dist\{#MyAppExeName}"; DestDir: "{app}"; Flags: ignoreversion
+Source: "..\dist\dictionary.json"; DestDir: "{app}"; Flags: ignoreversion
 
 [Icons]
 Name: "{autoprograms}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"

--- a/scripts/package.ps1
+++ b/scripts/package.ps1
@@ -13,12 +13,19 @@ if (-not (Test-Path $venvActivate)) {
 }
 
 & $venvActivate
-pyinstaller --noconfirm --clean --onefile --windowed --name Editorial --collect-all en_core_web_sm --collect-all spellchecker editorial.py
+pyinstaller --noconfirm --clean --onefile --windowed --name Editorial --collect-all en_core_web_sm --collect-all pyspellchecker editorial.py
 
-Write-Host "[2/4] Creating portable ZIP package..."
+Write-Host "[2/4] Creating portable ZIP package and extracting dictionary..."
 $distExe = Join-Path $repo "dist\Editorial.exe"
 if (-not (Test-Path $distExe)) {
     throw "Expected executable not found at $distExe"
+}
+
+# Extract and decompress the spellchecker dictionary
+$distDict = Join-Path $repo "dist\dictionary.json"
+python -c "import gzip, json, pkgutil, os; data = pkgutil.get_data('spellchecker', 'resources/en.json.gz'); open(r'$distDict', 'w', encoding='utf-8').write(json.dumps(json.loads(gzip.decompress(data).decode('utf-8')), indent=2))"
+if (-not (Test-Path $distDict)) {
+    Write-Warning "Could not extract dictionary.json from spellchecker"
 }
 
 $releaseDir = Join-Path $repo "release"
@@ -35,6 +42,9 @@ if (Test-Path $portableStage) {
 }
 New-Item -ItemType Directory -Force -Path $portableStage | Out-Null
 Copy-Item -Path $distExe -Destination (Join-Path $portableStage "Editorial.exe") -Force
+if (Test-Path $distDict) {
+    Copy-Item -Path $distDict -Destination (Join-Path $portableStage "dictionary.json") -Force
+}
 Compress-Archive -Path (Join-Path $portableStage "*") -DestinationPath $portableZip -CompressionLevel Optimal
 Remove-Item -Path $portableStage -Recurse -Force
 


### PR DESCRIPTION
Fixes PyInstaller bundling of `pyspellchecker` by using the correct hook name (`--collect-all pyspellchecker`), and extracts the default english dictionary as `dictionary.json` alongside the executable so the user can easily update or add words to the main text file.

---
*PR created automatically by Jules for task [8978404208983268217](https://jules.google.com/task/8978404208983268217) started by @FoolishFrost*